### PR TITLE
picasso: Fix file_contexts' error

### DIFF
--- a/sepolicy/private/file_contexts
+++ b/sepolicy/private/file_contexts
@@ -8,3 +8,4 @@
 
 # Kernel modules in /system
 /system/lib/modules(/.*)?    u:object_r:system_file:s0
+#


### PR DESCRIPTION
Avoids "u:object_r:system_file:s0#######" error in out/target/product/picasso/obj/ETC/file_contexts_intermediates/file_contexts.concat.tmp

Works in Android Q and R.